### PR TITLE
Support app-defined Anchor instructions

### DIFF
--- a/Sources/Solana/Extensions/Anchor/AnchorInstruction.swift
+++ b/Sources/Solana/Extensions/Anchor/AnchorInstruction.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+public struct AnchorPda {
+    public let address: PublicKey
+    public let bump: UInt8
+}
+
+extension PublicKey {
+    public static func findAnchorPda(anchorSeed: Data, programId: PublicKey) -> Result<AnchorPda, Error> {
+        findProgramAddress(
+            seeds: [anchorSeed],
+            programId: programId)
+            .map { (address, bump) in
+                AnchorPda(address: address, bump: bump)
+            }
+    }
+}
+
+extension Account.Meta {
+    public init(anchorPda: AnchorPda, isWritable: Bool) {
+        self.init(publicKey: anchorPda.address, isSigner: false, isWritable: isWritable)
+    }
+}
+
+public protocol AnchorInstruction: BorshSerializable {
+    var methodName: String { get }
+}
+
+extension TransactionInstruction {
+    public init?(accounts: [Account.Meta], programId: PublicKey, anchorInstruction: AnchorInstruction) {
+        var instructionData = Data()
+        let instructionHash = sha256(data: "global:\(anchorInstruction.methodName)".data(using: .utf8)!)
+        instructionData.append(instructionHash.subdata(in: 0..<8))
+        do {
+            try anchorInstruction.serialize(to: &instructionData)
+            self.init(keys: accounts, programId: programId, data: [instructionData])
+        } catch {
+            return nil
+        }
+    }
+}

--- a/Sources/Solana/Extensions/PublicKey/PublicKey+AssociatedTokenProgram.swift
+++ b/Sources/Solana/Extensions/PublicKey/PublicKey+AssociatedTokenProgram.swift
@@ -28,7 +28,7 @@ extension PublicKey {
     }
 
     // MARK: - Helpers
-    private static func findProgramAddress(
+    public static func findProgramAddress(
         seeds: [Data],
         programId: Self
     ) -> Result<(Self, UInt8), Error> {


### PR DESCRIPTION
Resolves #148 

This is being created as DRAFT for discussion.

* The feature added is described in the README.
* Change is additive in a single file, with one exception: a change to make `findProgramAddress` public.
* Note that `findProgramAddress` could actually be `internal` - but it seems like it should be a public utility function for any programs using this package (fixes #144 too).
* Sadly, the existing tests are broken (see #149), and I didn't write any new tests for this - I would love to add some tests but I'm trying to encourage some discussion around how to best achieve this (Anchor support) before spending lots of time on it. It works for our Anchor program, and provides a cleanish way for apps to talk directly to their own Solana programs.
* I know there's a separate Anchor.swift repo, but it appears to be abandoned.
* There are many fancy things that *could* be done - parsing IDL; property wrappers to provide function parameter hints and auto-implement serialization; but this seems like a good place to start discussion. It's simple, it works, it can be extended.
* I put all the Anchor support code in one file, but its location is probably wrong, and perhaps some of these bits could be elsewhere - I welcome discussion/suggestions on how to tidy this up.

