### PR TITLE
namespace solana token program

### DIFF
--- a/Sources/Solana/Programs/TokenProgram.swift
+++ b/Sources/Solana/Programs/TokenProgram.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+public typealias SolanaTokenProgram = TokenProgram
+
 public struct TokenProgram {
     // MARK: - Nested type
     private struct Index {


### PR DESCRIPTION
This allows us to import and use `TokenProgram` in `metaplex-ios` without having to rename or deprecate either `TokenProgram` struct.