### PR TITLE
Introduce Account, HotWallet, Create AccountMeta

### DIFF
--- a/Sources/Solana/Actions/createTokenAccount/createTokenAccount.swift
+++ b/Sources/Solana/Actions/createTokenAccount/createTokenAccount.swift
@@ -60,7 +60,7 @@ extension Action {
             return
         }
         // create new account for token
-        guard let newAccount = Account(network: self.router.endpoint.network) else {
+        guard let newAccount = HotAccount(network: self.router.endpoint.network) else {
             onComplete(.failure(SolanaError.unauthorized))
             return
         }

--- a/Sources/Solana/Actions/swap/swap.swift
+++ b/Sources/Solana/Actions/swap/swap.swift
@@ -87,7 +87,7 @@ extension Action {
             var destination = destination
 
             // add userTransferAuthority
-            guard let userTransferAuthority = Account(network: self.router.endpoint.network) else {
+            guard let userTransferAuthority = HotAccount(network: self.router.endpoint.network) else {
                 return .failure(SolanaError.other("Unsupported swapping tokens"))
             }
 
@@ -217,7 +217,7 @@ extension Action {
         signers: inout [Account],
         minimumBalanceForRentExemption: UInt64
     ) -> Result<Account, Error> {
-        guard let newAccount = Account(network: self.router.endpoint.network) else {
+        guard let newAccount = HotAccount(network: self.router.endpoint.network) else {
             return .failure(SolanaError.invalidRequest(reason: "Could not create new Account"))
         }
 
@@ -258,7 +258,7 @@ extension Action {
         signers: inout [Account],
         minimumBalanceForRentExemption: UInt64
     ) -> Result<Account, Error> {
-        guard let newAccount = Account(network: self.router.endpoint.network) else {
+        guard let newAccount = HotAccount(network: self.router.endpoint.network) else {
             return .failure(SolanaError.invalidRequest(reason: "Could not create new Account"))
         }
 

--- a/Sources/Solana/Extensions/AccountMeta+Extensions.swift
+++ b/Sources/Solana/Extensions/AccountMeta+Extensions.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-extension Array where Element == Account.Meta {
+extension Array where Element == AccountMeta {
     func index(ofElementWithPublicKey publicKey: PublicKey) -> Result<Int, Error> {
         guard let index = firstIndex(where: {$0.publicKey == publicKey}) else {
             return .failure( SolanaError.other("Could not found accountIndex"))}

--- a/Sources/Solana/Models/ConfirmedTransaction.swift
+++ b/Sources/Solana/Models/ConfirmedTransaction.swift
@@ -11,7 +11,7 @@ public struct ConfirmedTransactionFromBlock: Decodable {
 
 public extension ConfirmedTransaction {
     struct Message: Decodable {
-        public let accountKeys: [Account.Meta]
+        public let accountKeys: [AccountMeta]
         public let instructions: [ParsedInstruction]
         public let recentBlockhash: String
     }

--- a/Sources/Solana/Models/SendingTransaction/Message.swift
+++ b/Sources/Solana/Models/SendingTransaction/Message.swift
@@ -6,7 +6,7 @@ extension Transaction {
         private static let RECENT_BLOCK_HASH_LENGTH = 32
 
         // MARK: - Properties
-        var accountKeys: [Account.Meta]
+        var accountKeys: [AccountMeta]
         var recentBlockhash: String
         //        var instructions: [Transaction.Instruction]
         var programInstructions: [TransactionInstruction]

--- a/Sources/Solana/Models/TransactionInstruction.swift
+++ b/Sources/Solana/Models/TransactionInstruction.swift
@@ -2,17 +2,17 @@ import Foundation
 import Beet
 
 public struct TransactionInstruction: Decodable {
-    public let keys: [Account.Meta]
+    public let keys: [AccountMeta]
     public let programId: PublicKey
     public let data: [UInt8]
 
-    init(keys: [Account.Meta], programId: PublicKey, data: [BytesEncodable]) {
+    init(keys: [AccountMeta], programId: PublicKey, data: [BytesEncodable]) {
         self.keys = keys
         self.programId = programId
         self.data = data.bytes
     }
 
-    public init(keys: [Account.Meta], programId: PublicKey, data: [UInt8]) {
+    public init(keys: [AccountMeta], programId: PublicKey, data: [UInt8]) {
         self.keys = keys
         self.programId = programId
         self.data = data

--- a/Sources/Solana/Programs/SystemProgram.swift
+++ b/Sources/Solana/Programs/SystemProgram.swift
@@ -17,8 +17,8 @@ public struct SystemProgram {
 
         TransactionInstruction(
             keys: [
-                Account.Meta(publicKey: fromPublicKey, isSigner: true, isWritable: true),
-                Account.Meta(publicKey: newPubkey, isSigner: true, isWritable: true)
+                AccountMeta(publicKey: fromPublicKey, isSigner: true, isWritable: true),
+                AccountMeta(publicKey: newPubkey, isSigner: true, isWritable: true)
             ],
             programId: PublicKey.systemProgramId,
             data: [Index.create, lamports, space, programPubkey]
@@ -33,8 +33,8 @@ public struct SystemProgram {
 
         TransactionInstruction(
             keys: [
-                Account.Meta(publicKey: fromPublicKey, isSigner: true, isWritable: true),
-                Account.Meta(publicKey: toPublicKey, isSigner: false, isWritable: true)
+                AccountMeta(publicKey: fromPublicKey, isSigner: true, isWritable: true),
+                AccountMeta(publicKey: toPublicKey, isSigner: false, isWritable: true)
             ],
             programId: PublicKey.programId,
             data: [Index.transfer, lamports]
@@ -46,7 +46,7 @@ public struct SystemProgram {
     ) -> TransactionInstruction {
         TransactionInstruction(
             keys: [
-                Account.Meta(publicKey: destinationAccount, isSigner: false, isWritable: false)
+                AccountMeta(publicKey: destinationAccount, isSigner: false, isWritable: false)
             ],
             programId: .ownerValidationProgramId,
             data: [PublicKey.programId]

--- a/Sources/Solana/Programs/TokenProgram.swift
+++ b/Sources/Solana/Programs/TokenProgram.swift
@@ -26,8 +26,8 @@ public struct TokenProgram {
 
         TransactionInstruction(
             keys: [
-                Account.Meta(publicKey: mint, isSigner: false, isWritable: true),
-                Account.Meta(publicKey: PublicKey.sysvarRent, isSigner: false, isWritable: false)
+                AccountMeta(publicKey: mint, isSigner: false, isWritable: true),
+                AccountMeta(publicKey: PublicKey.sysvarRent, isSigner: false, isWritable: false)
             ],
             programId: tokenProgramId,
             data: [
@@ -49,10 +49,10 @@ public struct TokenProgram {
 
         TransactionInstruction(
             keys: [
-                Account.Meta(publicKey: account, isSigner: false, isWritable: true),
-                Account.Meta(publicKey: mint, isSigner: false, isWritable: false),
-                Account.Meta(publicKey: owner, isSigner: false, isWritable: false),
-                Account.Meta(publicKey: PublicKey.sysvarRent, isSigner: false, isWritable: false)
+                AccountMeta(publicKey: account, isSigner: false, isWritable: true),
+                AccountMeta(publicKey: mint, isSigner: false, isWritable: false),
+                AccountMeta(publicKey: owner, isSigner: false, isWritable: false),
+                AccountMeta(publicKey: PublicKey.sysvarRent, isSigner: false, isWritable: false)
             ],
             programId: programId,
             data: [Index.initializeAccount]
@@ -68,9 +68,9 @@ public struct TokenProgram {
     ) -> TransactionInstruction {
         TransactionInstruction(
             keys: [
-                Account.Meta(publicKey: source, isSigner: false, isWritable: true),
-                Account.Meta(publicKey: destination, isSigner: false, isWritable: true),
-                Account.Meta(publicKey: owner, isSigner: true, isWritable: true)
+                AccountMeta(publicKey: source, isSigner: false, isWritable: true),
+                AccountMeta(publicKey: destination, isSigner: false, isWritable: true),
+                AccountMeta(publicKey: owner, isSigner: true, isWritable: true)
             ],
             programId: tokenProgramId,
             data: [Index.transfer, amount]
@@ -86,22 +86,22 @@ public struct TokenProgram {
         amount: UInt64
     ) -> TransactionInstruction {
         var keys = [
-            Account.Meta(publicKey: account, isSigner: false, isWritable: true),
-            Account.Meta(publicKey: delegate, isSigner: false, isWritable: false)
+            AccountMeta(publicKey: account, isSigner: false, isWritable: true),
+            AccountMeta(publicKey: delegate, isSigner: false, isWritable: false)
         ]
 
         if multiSigners.isEmpty {
             keys.append(
-                Account.Meta(publicKey: owner, isSigner: true, isWritable: false)
+                AccountMeta(publicKey: owner, isSigner: true, isWritable: false)
             )
         } else {
             keys.append(
-                Account.Meta(publicKey: owner, isSigner: false, isWritable: false)
+                AccountMeta(publicKey: owner, isSigner: false, isWritable: false)
             )
 
             for signer in multiSigners {
                 keys.append(
-                    Account.Meta(publicKey: signer.publicKey, isSigner: true, isWritable: false)
+                    AccountMeta(publicKey: signer.publicKey, isSigner: true, isWritable: false)
                 )
             }
         }
@@ -123,9 +123,9 @@ public struct TokenProgram {
 
         TransactionInstruction(
             keys: [
-                Account.Meta(publicKey: mint, isSigner: false, isWritable: true),
-                Account.Meta(publicKey: destination, isSigner: false, isWritable: true),
-                Account.Meta(publicKey: authority, isSigner: true, isWritable: false)
+                AccountMeta(publicKey: mint, isSigner: false, isWritable: true),
+                AccountMeta(publicKey: destination, isSigner: false, isWritable: true),
+                AccountMeta(publicKey: authority, isSigner: true, isWritable: false)
             ],
             programId: tokenProgramId,
             data: [Index.mintTo, amount]
@@ -141,9 +141,9 @@ public struct TokenProgram {
 
         TransactionInstruction(
             keys: [
-                Account.Meta(publicKey: account, isSigner: false, isWritable: true),
-                Account.Meta(publicKey: destination, isSigner: false, isWritable: true),
-                Account.Meta(publicKey: owner, isSigner: false, isWritable: false)
+                AccountMeta(publicKey: account, isSigner: false, isWritable: true),
+                AccountMeta(publicKey: destination, isSigner: false, isWritable: true),
+                AccountMeta(publicKey: owner, isSigner: false, isWritable: false)
             ],
             programId: tokenProgramId,
             data: [Index.closeAccount]
@@ -161,9 +161,9 @@ public struct TokenProgram {
         decimals: Decimals
     ) -> TransactionInstruction {
         var keys = [
-            Account.Meta(publicKey: source, isSigner: false, isWritable: true),
-            Account.Meta(publicKey: mint, isSigner: false, isWritable: false),
-            Account.Meta(publicKey: destination, isSigner: false, isWritable: true)
+            AccountMeta(publicKey: source, isSigner: false, isWritable: true),
+            AccountMeta(publicKey: mint, isSigner: false, isWritable: false),
+            AccountMeta(publicKey: destination, isSigner: false, isWritable: true)
         ]
 
         if multiSigners.count == 0 {

--- a/Sources/Solana/Programs/TokenSwapProgram.swift
+++ b/Sources/Solana/Programs/TokenSwapProgram.swift
@@ -28,20 +28,20 @@ public struct TokenSwapProgram {
         minimumAmountOut: UInt64
     ) -> TransactionInstruction {
         var keys = [
-            Account.Meta(publicKey: tokenSwap, isSigner: false, isWritable: false),
-            Account.Meta(publicKey: authority, isSigner: false, isWritable: false),
-            Account.Meta(publicKey: userTransferAuthority, isSigner: true, isWritable: false),
-            Account.Meta(publicKey: userSource, isSigner: false, isWritable: true),
-            Account.Meta(publicKey: poolSource, isSigner: false, isWritable: true),
-            Account.Meta(publicKey: poolDestination, isSigner: false, isWritable: true),
-            Account.Meta(publicKey: userDestination, isSigner: false, isWritable: true),
-            Account.Meta(publicKey: poolMint, isSigner: false, isWritable: true),
-            Account.Meta(publicKey: feeAccount, isSigner: false, isWritable: true),
-            Account.Meta(publicKey: tokenProgramId, isSigner: false, isWritable: false)
+            AccountMeta(publicKey: tokenSwap, isSigner: false, isWritable: false),
+            AccountMeta(publicKey: authority, isSigner: false, isWritable: false),
+            AccountMeta(publicKey: userTransferAuthority, isSigner: true, isWritable: false),
+            AccountMeta(publicKey: userSource, isSigner: false, isWritable: true),
+            AccountMeta(publicKey: poolSource, isSigner: false, isWritable: true),
+            AccountMeta(publicKey: poolDestination, isSigner: false, isWritable: true),
+            AccountMeta(publicKey: userDestination, isSigner: false, isWritable: true),
+            AccountMeta(publicKey: poolMint, isSigner: false, isWritable: true),
+            AccountMeta(publicKey: feeAccount, isSigner: false, isWritable: true),
+            AccountMeta(publicKey: tokenProgramId, isSigner: false, isWritable: false)
         ]
 
         if let hostFeeAccount = hostFeeAccount {
-            keys.append(Account.Meta(publicKey: hostFeeAccount, isSigner: false, isWritable: true))
+            keys.append(AccountMeta(publicKey: hostFeeAccount, isSigner: false, isWritable: true))
         }
 
         return TransactionInstruction(
@@ -70,15 +70,15 @@ public struct TokenSwapProgram {
 
         TransactionInstruction(
             keys: [
-                Account.Meta(publicKey: tokenSwap, isSigner: false, isWritable: false),
-                Account.Meta(publicKey: authority, isSigner: false, isWritable: false),
-                Account.Meta(publicKey: sourceA, isSigner: false, isWritable: true),
-                Account.Meta(publicKey: sourceB, isSigner: false, isWritable: true),
-                Account.Meta(publicKey: intoA, isSigner: false, isWritable: true),
-                Account.Meta(publicKey: intoB, isSigner: false, isWritable: true),
-                Account.Meta(publicKey: poolToken, isSigner: false, isWritable: true),
-                Account.Meta(publicKey: poolAccount, isSigner: false, isWritable: true),
-                Account.Meta(publicKey: tokenProgramId, isSigner: false, isWritable: true)
+                AccountMeta(publicKey: tokenSwap, isSigner: false, isWritable: false),
+                AccountMeta(publicKey: authority, isSigner: false, isWritable: false),
+                AccountMeta(publicKey: sourceA, isSigner: false, isWritable: true),
+                AccountMeta(publicKey: sourceB, isSigner: false, isWritable: true),
+                AccountMeta(publicKey: intoA, isSigner: false, isWritable: true),
+                AccountMeta(publicKey: intoB, isSigner: false, isWritable: true),
+                AccountMeta(publicKey: poolToken, isSigner: false, isWritable: true),
+                AccountMeta(publicKey: poolAccount, isSigner: false, isWritable: true),
+                AccountMeta(publicKey: tokenProgramId, isSigner: false, isWritable: true)
             ],
             programId: swapProgramId,
             data: [Index.deposit, poolTokenAmount, maximumTokenA, maximumTokenB]
@@ -105,16 +105,16 @@ public struct TokenSwapProgram {
 
         TransactionInstruction(
             keys: [
-                Account.Meta(publicKey: tokenSwap, isSigner: false, isWritable: false),
-                Account.Meta(publicKey: authority, isSigner: false, isWritable: false),
-                Account.Meta(publicKey: poolMint, isSigner: false, isWritable: true),
-                Account.Meta(publicKey: sourcePoolAccount, isSigner: false, isWritable: true),
-                Account.Meta(publicKey: fromA, isSigner: false, isWritable: true),
-                Account.Meta(publicKey: fromB, isSigner: false, isWritable: true),
-                Account.Meta(publicKey: userAccountA, isSigner: false, isWritable: true),
-                Account.Meta(publicKey: userAccountB, isSigner: false, isWritable: true),
-                Account.Meta(publicKey: feeAccount, isSigner: false, isWritable: false),
-                Account.Meta(publicKey: tokenProgramId, isSigner: false, isWritable: false)
+                AccountMeta(publicKey: tokenSwap, isSigner: false, isWritable: false),
+                AccountMeta(publicKey: authority, isSigner: false, isWritable: false),
+                AccountMeta(publicKey: poolMint, isSigner: false, isWritable: true),
+                AccountMeta(publicKey: sourcePoolAccount, isSigner: false, isWritable: true),
+                AccountMeta(publicKey: fromA, isSigner: false, isWritable: true),
+                AccountMeta(publicKey: fromB, isSigner: false, isWritable: true),
+                AccountMeta(publicKey: userAccountA, isSigner: false, isWritable: true),
+                AccountMeta(publicKey: userAccountB, isSigner: false, isWritable: true),
+                AccountMeta(publicKey: feeAccount, isSigner: false, isWritable: false),
+                AccountMeta(publicKey: tokenProgramId, isSigner: false, isWritable: false)
             ],
             programId: swapProgramId,
             data: [Index.withdraw, poolTokenAmount, minimumTokenA, minimumTokenB])

--- a/Tests/SolanaTests/Actions/closeTokenAccount/closeTokenAccount.swift
+++ b/Tests/SolanaTests/Actions/closeTokenAccount/closeTokenAccount.swift
@@ -9,7 +9,7 @@ class closeTokenAccount: XCTestCase {
     override func setUpWithError() throws {
         let wallet: TestsWallet = .devnet
         solanaSDK = Solana(router: NetworkingRouter(endpoint: endpoint))
-        account = Account(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
+        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
     }
     
     func testCloseAccountInstruction() {

--- a/Tests/SolanaTests/Actions/createAssociatedTokenAccount/createAssociatedTokenAccount.swift
+++ b/Tests/SolanaTests/Actions/createAssociatedTokenAccount/createAssociatedTokenAccount.swift
@@ -12,7 +12,7 @@ class createAssociatedTokenAccount: XCTestCase {
         let wallet: TestsWallet = .devnet
         networkRouterMock = NetworkingRouterMock()
         solana = Solana(router: networkRouterMock)
-        account = Account(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
+        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
     }
     
     override func tearDownWithError() throws {

--- a/Tests/SolanaTests/Actions/createTokenAccount/createTokenAccount.swift
+++ b/Tests/SolanaTests/Actions/createTokenAccount/createTokenAccount.swift
@@ -12,7 +12,7 @@ class createTokenAccount: XCTestCase {
         let wallet: TestsWallet = .devnet
         networkRouterMock = NetworkingRouterMock()
         solana = Solana(router: networkRouterMock)
-        account = Account(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
+        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
     }
 
     override func tearDownWithError() throws {

--- a/Tests/SolanaTests/Actions/getMintData/getMintData.swift
+++ b/Tests/SolanaTests/Actions/getMintData/getMintData.swift
@@ -9,7 +9,7 @@ class getMintData: XCTestCase {
     override func setUpWithError() throws {
         let wallet: TestsWallet = .devnet
         solana = Solana(router: NetworkingRouter(endpoint: endpoint))
-        account = Account(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
+        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
     }
     
     func testGetMintData() {

--- a/Tests/SolanaTests/Actions/getTokenWallets/getTokenWallets.swift
+++ b/Tests/SolanaTests/Actions/getTokenWallets/getTokenWallets.swift
@@ -9,7 +9,7 @@ class getTokenWallets: XCTestCase {
     override func setUpWithError() throws {
         let wallet: TestsWallet = .getWallets
         solana = Solana(router: NetworkingRouter(endpoint: endpoint))
-        account = Account(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
+        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
     }
     
     func testsGetTokenWallets() {

--- a/Tests/SolanaTests/Actions/sendSOL/sendSOL.swift
+++ b/Tests/SolanaTests/Actions/sendSOL/sendSOL.swift
@@ -9,7 +9,7 @@ class sendSOL: XCTestCase {
     override func setUpWithError() throws {
         let wallet: TestsWallet = .devnet
         solana = Solana(router: NetworkingRouter(endpoint: endpoint))
-        account = Account(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)! // 5Zzguz4NsSRFxGkHfM4FmsFpGZiCDtY72zH2jzMcqkJx
+        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)! // 5Zzguz4NsSRFxGkHfM4FmsFpGZiCDtY72zH2jzMcqkJx
     }
     
     func testSendSOLFromBalance() {

--- a/Tests/SolanaTests/Actions/sendSPLTokens/sendSPLTokens.swift
+++ b/Tests/SolanaTests/Actions/sendSPLTokens/sendSPLTokens.swift
@@ -5,11 +5,11 @@ class sendSPLTokens: XCTestCase {
     var endpoint = RPCEndpoint.devnetSolana
     var solana: Solana!
     var account: Account!
-
+    
     override func setUpWithError() throws {
         let wallet: TestsWallet = .devnet
         solana = Solana(router: NetworkingRouter(endpoint: endpoint))
-        account = Account(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
+        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
         _ = try solana.api.requestAirdrop(account: account.publicKey.base58EncodedString, lamports: 100.toLamport(decimals: 9))?.get()
     }
     
@@ -17,7 +17,7 @@ class sendSPLTokens: XCTestCase {
         let mintAddress = "6AUM4fSvCAxCugrbJPFxTqYFp9r3axYx973yoSyzDYVH"
         let source = "8hoBQbSFKfDK3Mo7Wwc15Pp2bbkYuJE8TdQmnHNDjXoQ"
         let destination = "8Poh9xusEcKtmYZ9U4FSfjrrrQR155TLWGAsyFWjjKxB"
-
+        
         let transactionId = try! solana.action.sendSPLTokens(
             mintAddress: mintAddress,
             decimals: 5,

--- a/Tests/SolanaTests/Actions/serializeAndSendWithFee/serializeAndSendWithFee.swift
+++ b/Tests/SolanaTests/Actions/serializeAndSendWithFee/serializeAndSendWithFee.swift
@@ -9,7 +9,7 @@ class serializeAndSendWithFee: XCTestCase {
     override func setUpWithError() throws {
         let wallet: TestsWallet = .devnet
         solana = Solana(router: NetworkingRouter(endpoint: endpoint))
-        account = Account(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
+        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
     }
 
     func testSimulationSerializeAndSend() {

--- a/Tests/SolanaTests/Actions/swap/swap.swift
+++ b/Tests/SolanaTests/Actions/swap/swap.swift
@@ -10,7 +10,7 @@ class swap: XCTestCase {
     override func setUpWithError() throws {
         let wallet: TestsWallet = .devnet
         solana = Solana(router: NetworkingRouter(endpoint: endpoint))
-        account = Account(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
+        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
     }
 
     /*func testSwapToken() {

--- a/Tests/SolanaTests/Api/Methods.swift
+++ b/Tests/SolanaTests/Api/Methods.swift
@@ -9,7 +9,7 @@ class Methods: XCTestCase {
     override func setUpWithError() throws {
         let wallet: TestsWallet = .devnet
         solana = Solana(router: NetworkingRouter(endpoint: endpoint))
-        account = Account(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
+        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
     }
 
     func testGetPureAccountInfo() {

--- a/Tests/SolanaTests/Api/MethodsAsync.swift
+++ b/Tests/SolanaTests/Api/MethodsAsync.swift
@@ -11,7 +11,7 @@ class MethodsAsync: XCTestCase {
     override func setUpWithError() throws {
         let wallet: TestsWallet = .devnet
         solana = Solana(router: NetworkingRouter(endpoint: endpoint))
-        account = Account(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
+        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
     }
 
     func testGetAccountInfo() async throws {

--- a/Tests/SolanaTests/Models/PublicKey.swift
+++ b/Tests/SolanaTests/Models/PublicKey.swift
@@ -110,7 +110,7 @@ class PublicKeyTests: XCTestCase {
         let secretKey = Base58.decode("4Z7cXSyeFR8wNGMVXUE1TwtKn5D5Vu7FzEv69dokLv7KrQk7h6pu4LF8ZRR9yQBhc7uSM6RTTZtU1fmaxiNrxXrs")
         XCTAssertNotNil(secretKey)
         
-        let account = Account(secretKey: Data(secretKey))!
+        let account = HotAccount(secretKey: Data(secretKey))!
         
         XCTAssertEqual("QqCCvshxtqMAL2CVALqiJB7uEeE5mjSPsseQdDzsRUo", account.publicKey.base58EncodedString)
         XCTAssertEqual(64, account.secretKey.count)
@@ -119,19 +119,19 @@ class PublicKeyTests: XCTestCase {
     func testRestoreAccountFromSeedPhrase() {
         let phrase12 = "miracle pizza supply useful steak border same again youth silver access hundred"
             .components(separatedBy: " ")
-        let account12 = Account(phrase: phrase12, network: .mainnetBeta)!
+        let account12 = HotAccount(phrase: phrase12, network: .mainnetBeta)!
         XCTAssertEqual(account12.publicKey.base58EncodedString, "HnXJX1Bvps8piQwDYEYC6oea9GEkvQvahvRj3c97X9xr")
         
         let phrase24 = "budget resource fluid mutual ankle salt demise long burst sting doctor ozone risk magic wrap clap post pole jungle great update air interest abandon"
             .components(separatedBy: " ")
-        let account24 = Account(phrase: phrase24, network: .mainnetBeta)!
+        let account24 = HotAccount(phrase: phrase24, network: .mainnetBeta)!
         XCTAssertEqual(account24.publicKey.base58EncodedString, "9avcmC97zLPwHKXiDz6GpXyjvPn9VcN3ggqM5gsRnjvv")
     }
     
     func testRestoreAccountFromSeedPhraseBip32Deprecated() {
         let phrase24 = "hint begin crowd dolphin drive render finger above sponsor prize runway invest dizzy pony bitter trial ignore crop please industry hockey wire use side"
             .components(separatedBy: " ")
-        let account24 = Account(phrase: phrase24, network: .mainnetBeta, derivablePath: DerivablePath(
+        let account24 = HotAccount(phrase: phrase24, network: .mainnetBeta, derivablePath: DerivablePath(
             type: .bip32Deprecated,
             walletIndex: 0,
             accountIndex: 0

--- a/Tests/SolanaTests/TokenInfo/TokenInfoTests.swift
+++ b/Tests/SolanaTests/TokenInfo/TokenInfoTests.swift
@@ -11,7 +11,7 @@ class TokenInfoTests: XCTestCase {
         let wallet: TestsWallet = .devnet
         let tokenProvider = try! TokenListProvider(path: getFileFrom("TokenInfo/mainnet-beta.tokens"))
         solanaSDK = Solana(router: NetworkingRouter(endpoint: endpoint), tokenProvider: tokenProvider)
-        account = Account(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
+        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
     }
     
     func testCloseAccountInstruction() {


### PR DESCRIPTION
This PRs Extract the Account to an interface. The idea is that other types of wallets can be implemented. 

The problem is that the current Account also contains Meta. This will create a breaking change on every transaction using Account.Meta. This was a bad implementation from the beginning. The Signing Method will be extracted to the account and live outside the transaction.

Hot wallet implementation is also added to maintain functionality. 