### PR TITLE
Hides keychain object

### DIFF
--- a/Sources/Solana/Vendor/AskCoin-HD/Keychain.swift
+++ b/Sources/Solana/Vendor/AskCoin-HD/Keychain.swift
@@ -17,7 +17,7 @@ let BTCMasterKeychainPath = "m"
 let BTCKeychainHardenedSymbol = "'"
 let BTCKeychainPathSeparator = "/"
 
-public class Keychain: NSObject {
+class Keychain: NSObject {
 
 	enum KeyDerivationError: Error {
 		case indexInvalid


### PR DESCRIPTION
## Description
- The Keychain object from AnyCoin is not required to be exposed. 

## Work Completed
- Keychain Object is only relevant for HotAccount implementation not to be exposed

## API Changes
- Keychain is not public anymore