### PR TITLE
Remove network from Hotwallet

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,21 +93,21 @@ public struct HotAccount:  Account {
 Create Hot Account.
 
 ```swift
-let account = HotAccount(network: .mainnetBeta)
+let account = HotAccount()
 ```
 
 Create Hot Account from the seed phrase.
 
 ```swift
 let phrase12 = "miracle pizza supply useful steak border same again youth silver access hundred".components(separatedBy: " ")
-let account12 = HotAccount(phrase: phrase12, network: .mainnetBeta)
+let account12 = HotAccount(phrase: phrase12)
 ```
 
 Create a Hot Account from bip32Deprecated("m/501'") seed phrase. Yes, we support Wallet Index and several accounts from the same Mnemonic. This is helpful for wallet creation. 
 
 ```swift
 let phrase24 = "hint begin crowd dolphin drive render finger above sponsor prize runway invest dizzy pony bitter trial ignore crop please industry hockey wire use side".components(separatedBy: " ")
-let account24 = HotAccount(phrase: phrase24, network: .mainnetBeta, derivablePath: DerivablePath( 
+let account24 = HotAccount(phrase: phrase24, derivablePath: DerivablePath( 
         type: .bip32Deprecated,
         walletIndex: 0,
         accountIndex: 0
@@ -125,7 +125,7 @@ To create a new seed phrase only use `Mnemonic()`. It will create a 256 strength
 
 ```swift
 let phrase= Mnemonic())
-let account = HotAccount(phrase: phrase, network: .mainnetBeta)
+let account = HotAccount(phrase: phrase)
 ```
 
 ## RPC API calls

--- a/Sources/Solana/Actions/createTokenAccount/createTokenAccount.swift
+++ b/Sources/Solana/Actions/createTokenAccount/createTokenAccount.swift
@@ -60,7 +60,7 @@ extension Action {
             return
         }
         // create new account for token
-        guard let newAccount = HotAccount(network: self.router.endpoint.network) else {
+        guard let newAccount = HotAccount() else {
             onComplete(.failure(SolanaError.unauthorized))
             return
         }

--- a/Sources/Solana/Actions/swap/swap.swift
+++ b/Sources/Solana/Actions/swap/swap.swift
@@ -87,7 +87,7 @@ extension Action {
             var destination = destination
 
             // add userTransferAuthority
-            guard let userTransferAuthority = HotAccount(network: self.router.endpoint.network) else {
+            guard let userTransferAuthority = HotAccount() else {
                 return .failure(SolanaError.other("Unsupported swapping tokens"))
             }
 
@@ -217,7 +217,7 @@ extension Action {
         signers: inout [Account],
         minimumBalanceForRentExemption: UInt64
     ) -> Result<Account, Error> {
-        guard let newAccount = HotAccount(network: self.router.endpoint.network) else {
+        guard let newAccount = HotAccount() else {
             return .failure(SolanaError.invalidRequest(reason: "Could not create new Account"))
         }
 
@@ -258,7 +258,7 @@ extension Action {
         signers: inout [Account],
         minimumBalanceForRentExemption: UInt64
     ) -> Result<Account, Error> {
-        guard let newAccount = HotAccount(network: self.router.endpoint.network) else {
+        guard let newAccount = HotAccount() else {
             return .failure(SolanaError.invalidRequest(reason: "Could not create new Account"))
         }
 

--- a/Sources/Solana/Models/Account.swift
+++ b/Sources/Solana/Models/Account.swift
@@ -16,7 +16,7 @@ public struct HotAccount: Codable, Hashable, Account {
         return data
     }
     
-    public init?(phrase: [String] = [], network: Network, derivablePath: DerivablePath? = nil) {
+    public init?(phrase: [String] = [], derivablePath: DerivablePath? = nil) {
         let mnemonic: Mnemonic
         var phrase = phrase.filter {!$0.isEmpty}
         if !phrase.isEmpty,
@@ -32,7 +32,7 @@ public struct HotAccount: Codable, Hashable, Account {
 
         switch derivablePath.type {
         case .bip32Deprecated:
-            guard let keychain = try? Keychain(seedString: phrase.joined(separator: " "), network: network.cluster)  else {
+            guard let keychain = try? Keychain(seedString: phrase.joined(separator: " "))  else {
                 return nil
             }
             guard let seed = try? keychain.derivedKeychain(at: derivablePath.rawValue).privateKey else {

--- a/Sources/Solana/Vendor/AskCoin-HD/Keychain.swift
+++ b/Sources/Solana/Vendor/AskCoin-HD/Keychain.swift
@@ -32,8 +32,7 @@ class Keychain: NSObject {
 	private var chainCode: Data?
 
 	fileprivate var isMasterKey = false
-    var isTestnet = false
-
+    
 	var depth: UInt8 = 0
 	var hardened = false
 	var index: UInt32 = 0
@@ -42,7 +41,7 @@ class Keychain: NSObject {
 
 	}
 
-    public convenience init?(seedString: String, network: String) throws {
+    public convenience init?(seedString: String) throws {
         guard let seedData = Mnemonic(phrase: seedString.components(separatedBy: " ")) else {
             return nil
         }
@@ -54,7 +53,6 @@ class Keychain: NSObject {
         }
         self.init(hmac: hmac.bytes)
         isMasterKey = true
-        isTestnet = network == "devnet" || network == "testnet"
 	}
 
 	public init(hmac: [UInt8]) {
@@ -97,7 +95,7 @@ class Keychain: NSObject {
 
 		var toReturn = Data()
 
-		let version = !isTestnet ? BTCKeychainMainnetPrivateVersion : BTCKeychainTestnetPrivateVersion
+		let version = BTCKeychainMainnetPrivateVersion
 		toReturn += self.extendedKeyPrefix(with: version)
 
 		toReturn += UInt8(0).ask_hexToData()
@@ -121,7 +119,7 @@ class Keychain: NSObject {
 
 		var toReturn = Data()
 
-		let version = !isTestnet ? BTCKeychainMainnetPublicVersion : BTCKeychainTestnetPublicVersion
+		let version = BTCKeychainMainnetPublicVersion
 		toReturn += self.extendedKeyPrefix(with: version)
 
 		if let pubkey = self.publicKey {

--- a/Sources/Solana/Vendor/AskCoin-HD/Keychain.swift
+++ b/Sources/Solana/Vendor/AskCoin-HD/Keychain.swift
@@ -17,7 +17,7 @@ let BTCMasterKeychainPath = "m"
 let BTCKeychainHardenedSymbol = "'"
 let BTCKeychainPathSeparator = "/"
 
-public class Keychain: NSObject {
+class Keychain: NSObject {
 
 	enum KeyDerivationError: Error {
 		case indexInvalid

--- a/Tests/SolanaTests/Actions/closeTokenAccount/closeTokenAccount.swift
+++ b/Tests/SolanaTests/Actions/closeTokenAccount/closeTokenAccount.swift
@@ -9,7 +9,7 @@ class closeTokenAccount: XCTestCase {
     override func setUpWithError() throws {
         let wallet: TestsWallet = .devnet
         solanaSDK = Solana(router: NetworkingRouter(endpoint: endpoint))
-        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
+        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "))!
     }
     
     func testCloseAccountInstruction() {

--- a/Tests/SolanaTests/Actions/createAssociatedTokenAccount/createAssociatedTokenAccount.swift
+++ b/Tests/SolanaTests/Actions/createAssociatedTokenAccount/createAssociatedTokenAccount.swift
@@ -12,7 +12,7 @@ class createAssociatedTokenAccount: XCTestCase {
         let wallet: TestsWallet = .devnet
         networkRouterMock = NetworkingRouterMock()
         solana = Solana(router: networkRouterMock)
-        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
+        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "))!
     }
     
     override func tearDownWithError() throws {

--- a/Tests/SolanaTests/Actions/createAssociatedTokenAccount/createAssociatedTokenAccountAsync.swift
+++ b/Tests/SolanaTests/Actions/createAssociatedTokenAccount/createAssociatedTokenAccountAsync.swift
@@ -13,7 +13,7 @@ class createAssociatedTokenAccountAsync: XCTestCase {
         try super.setUpWithError()
         let wallet: TestsWallet = .devnet
         solana = Solana(router: NetworkingRouter(endpoint: .devnetSolana))
-        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
+        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "))!
     }
     
     func testGetOrCreateAssociatedTokenAccount() async throws {

--- a/Tests/SolanaTests/Actions/createTokenAccount/createTokenAccount.swift
+++ b/Tests/SolanaTests/Actions/createTokenAccount/createTokenAccount.swift
@@ -12,7 +12,7 @@ class createTokenAccount: XCTestCase {
         let wallet: TestsWallet = .devnet
         networkRouterMock = NetworkingRouterMock()
         solana = Solana(router: networkRouterMock)
-        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
+        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "))!
     }
 
     override func tearDownWithError() throws {

--- a/Tests/SolanaTests/Actions/createTokenAccount/createTokenAccountAsync.swift
+++ b/Tests/SolanaTests/Actions/createTokenAccount/createTokenAccountAsync.swift
@@ -5,23 +5,39 @@ import Solana
 @available(macOS 10.15, *)
 class createTokenAccountAsync: XCTestCase {
     var endpoint = RPCEndpoint.devnetSolana
+    var networkRouterMock: NetworkingRouterMock!
     var solana: Solana!
     var account: Account!
 
     override func setUpWithError() throws {
+        try super.setUpWithError()
         let wallet: TestsWallet = .devnet
-        solana = Solana(router: NetworkingRouter(endpoint: endpoint))
-        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
+        networkRouterMock = NetworkingRouterMock()
+        solana = Solana(router: networkRouterMock)
+        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "))!
     }
     
     func testCreateTokenAccount() async throws {
+        // arrange
         let mintAddress = "6AUM4fSvCAxCugrbJPFxTqYFp9r3axYx973yoSyzDYVH"
-        let account: (signature: String, newPubkey: String)? = try await solana.action.createTokenAccount( mintAddress: mintAddress, payer: account)
-        XCTAssertNotNil(account)
+        networkRouterMock.expectedResults.append(contentsOf: [
+            .success(.json(filename: "getRecentBlockhash")),
+            .success(.json(filename: "getMinimumBalanceForRentExemption")),
+            .success(.json(filename: "sendTransaction"))
+        ])
+
+        // act
+        let account: (signature: String, newPubkey: String)? = try! await solana.action.createTokenAccount( mintAddress: mintAddress, payer: self.account)
+        
+        // assert
+        XCTAssertEqual(networkRouterMock.requestCalled.count, 3)
+        XCTAssertEqual(account?.signature,
+                       "TWui8GhF8vp8BtiGXhvxgti7LJGpVu7hx4tXzi3pqSycipNbJokDcFayw8a9YdcKJ789fSRjU6CRwPJ2zNp52eB")
+        XCTAssertNotNil(account?.newPubkey)
     }
     
     func testCreateAccountInstruction() {
-        let instruction = SystemProgram.createAccountInstruction(from: PublicKey.programId, toNewPubkey: PublicKey.systemProgramId, lamports: 2039280, space: 165, programPubkey: PublicKey.systemProgramId)
+        let instruction = SystemProgram.createAccountInstruction(from: PublicKey.systemProgramId, toNewPubkey: PublicKey.systemProgramId, lamports: 2039280, space: 165, programPubkey: PublicKey.systemProgramId)
         
         XCTAssertEqual("11119os1e9qSs2u7TsThXqkBSRUo9x7kpbdqtNNbTeaxHGPdWbvoHsks9hpp6mb2ed1NeB", Base58.encode(instruction.data))
     }

--- a/Tests/SolanaTests/Actions/getMintData/getMintData.swift
+++ b/Tests/SolanaTests/Actions/getMintData/getMintData.swift
@@ -9,7 +9,7 @@ class getMintData: XCTestCase {
     override func setUpWithError() throws {
         let wallet: TestsWallet = .devnet
         solana = Solana(router: NetworkingRouter(endpoint: endpoint))
-        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
+        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "))!
     }
     
     func testGetMintData() {

--- a/Tests/SolanaTests/Actions/getMintData/getMintDataAsync.swift
+++ b/Tests/SolanaTests/Actions/getMintData/getMintDataAsync.swift
@@ -11,7 +11,7 @@ class getMintDataAsync: XCTestCase {
     override func setUpWithError() throws {
         let wallet: TestsWallet = .devnet
         solana = Solana(router: NetworkingRouter(endpoint: endpoint))
-        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
+        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "))!
     }
     
     func testGetMintData() async throws {

--- a/Tests/SolanaTests/Actions/getTokenWallets/getTokenWallets.swift
+++ b/Tests/SolanaTests/Actions/getTokenWallets/getTokenWallets.swift
@@ -9,7 +9,7 @@ class getTokenWallets: XCTestCase {
     override func setUpWithError() throws {
         let wallet: TestsWallet = .getWallets
         solana = Solana(router: NetworkingRouter(endpoint: endpoint))
-        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
+        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "))!
     }
     
     func testsGetTokenWallets() {

--- a/Tests/SolanaTests/Actions/getTokenWallets/getTokenWalletsAsync.swift
+++ b/Tests/SolanaTests/Actions/getTokenWallets/getTokenWalletsAsync.swift
@@ -11,7 +11,7 @@ class getTokenWalletsAsync: XCTestCase {
     override func setUpWithError() throws {
         let wallet: TestsWallet = .getWallets
         solana = Solana(router: NetworkingRouter(endpoint: endpoint))
-        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
+        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "))!
     }
     
     func testsGetTokenWallets() async throws {

--- a/Tests/SolanaTests/Actions/sendSOL/sendSOL.swift
+++ b/Tests/SolanaTests/Actions/sendSOL/sendSOL.swift
@@ -9,7 +9,7 @@ class sendSOL: XCTestCase {
     override func setUpWithError() throws {
         let wallet: TestsWallet = .devnet
         solana = Solana(router: NetworkingRouter(endpoint: endpoint))
-        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)! // 5Zzguz4NsSRFxGkHfM4FmsFpGZiCDtY72zH2jzMcqkJx
+        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "))! // 5Zzguz4NsSRFxGkHfM4FmsFpGZiCDtY72zH2jzMcqkJx
     }
     
     func testSendSOLFromBalance() {

--- a/Tests/SolanaTests/Actions/sendSOL/sendSOLAsync.swift
+++ b/Tests/SolanaTests/Actions/sendSOL/sendSOLAsync.swift
@@ -11,7 +11,7 @@ class sendSOLAsync: XCTestCase {
     override func setUpWithError() throws {
         let wallet: TestsWallet = .devnet
         solana = Solana(router: NetworkingRouter(endpoint: endpoint))
-        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)! // 5Zzguz4NsSRFxGkHfM4FmsFpGZiCDtY72zH2jzMcqkJx
+        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "))! // 5Zzguz4NsSRFxGkHfM4FmsFpGZiCDtY72zH2jzMcqkJx
     }
     
     func testSendSOLFromBalance() async throws {

--- a/Tests/SolanaTests/Actions/sendSPLTokens/sendSPLTokens.swift
+++ b/Tests/SolanaTests/Actions/sendSPLTokens/sendSPLTokens.swift
@@ -9,7 +9,7 @@ class sendSPLTokens: XCTestCase {
     override func setUpWithError() throws {
         let wallet: TestsWallet = .devnet
         solana = Solana(router: NetworkingRouter(endpoint: endpoint))
-        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
+        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "))!
         _ = try solana.api.requestAirdrop(account: account.publicKey.base58EncodedString, lamports: 100.toLamport(decimals: 9))?.get()
     }
     

--- a/Tests/SolanaTests/Actions/sendSPLTokens/sendSPLTokensAsync.swift
+++ b/Tests/SolanaTests/Actions/sendSPLTokens/sendSPLTokensAsync.swift
@@ -11,7 +11,7 @@ class sendSPLTokensAsync: XCTestCase {
     override func setUpWithError() throws {
         let wallet: TestsWallet = .devnet
         solana = Solana(router: NetworkingRouter(endpoint: endpoint))
-        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
+        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "))!
     }
     
     func testSendSPLTokenWithFee() async throws {

--- a/Tests/SolanaTests/Actions/serializeAndSendWithFee/serializeAndSendWithFee.swift
+++ b/Tests/SolanaTests/Actions/serializeAndSendWithFee/serializeAndSendWithFee.swift
@@ -9,7 +9,7 @@ class serializeAndSendWithFee: XCTestCase {
     override func setUpWithError() throws {
         let wallet: TestsWallet = .devnet
         solana = Solana(router: NetworkingRouter(endpoint: endpoint))
-        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
+        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "))!
     }
 
     func testSimulationSerializeAndSend() {

--- a/Tests/SolanaTests/Actions/serializeAndSendWithFee/serializeAndSendWithFeeAsync.swift
+++ b/Tests/SolanaTests/Actions/serializeAndSendWithFee/serializeAndSendWithFeeAsync.swift
@@ -11,7 +11,7 @@ class serializeAndSendWithFeeAsync: XCTestCase {
     override func setUpWithError() throws {
         let wallet: TestsWallet = .devnet
         solana = Solana(router: NetworkingRouter(endpoint: endpoint))
-        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
+        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "))!
     }
 
     func testSimulationSerializeAndSend() async throws {

--- a/Tests/SolanaTests/Actions/swap/swap.swift
+++ b/Tests/SolanaTests/Actions/swap/swap.swift
@@ -10,7 +10,7 @@ class swap: XCTestCase {
     override func setUpWithError() throws {
         let wallet: TestsWallet = .devnet
         solana = Solana(router: NetworkingRouter(endpoint: endpoint))
-        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
+        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "))!
     }
 
     /*func testSwapToken() {

--- a/Tests/SolanaTests/Api/Methods.swift
+++ b/Tests/SolanaTests/Api/Methods.swift
@@ -9,7 +9,7 @@ class Methods: XCTestCase {
     override func setUpWithError() throws {
         let wallet: TestsWallet = .devnet
         solana = Solana(router: NetworkingRouter(endpoint: endpoint))
-        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
+        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "))!
     }
 
     func testGetPureAccountInfo() {

--- a/Tests/SolanaTests/Api/MethodsAsync.swift
+++ b/Tests/SolanaTests/Api/MethodsAsync.swift
@@ -11,7 +11,7 @@ class MethodsAsync: XCTestCase {
     override func setUpWithError() throws {
         let wallet: TestsWallet = .devnet
         solana = Solana(router: NetworkingRouter(endpoint: endpoint))
-        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
+        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "))!
     }
 
     func testGetAccountInfo() async throws {

--- a/Tests/SolanaTests/Models/PublicKey.swift
+++ b/Tests/SolanaTests/Models/PublicKey.swift
@@ -119,19 +119,19 @@ class PublicKeyTests: XCTestCase {
     func testRestoreAccountFromSeedPhrase() {
         let phrase12 = "miracle pizza supply useful steak border same again youth silver access hundred"
             .components(separatedBy: " ")
-        let account12 = HotAccount(phrase: phrase12, network: .mainnetBeta)!
+        let account12 = HotAccount(phrase: phrase12)!
         XCTAssertEqual(account12.publicKey.base58EncodedString, "HnXJX1Bvps8piQwDYEYC6oea9GEkvQvahvRj3c97X9xr")
         
         let phrase24 = "budget resource fluid mutual ankle salt demise long burst sting doctor ozone risk magic wrap clap post pole jungle great update air interest abandon"
             .components(separatedBy: " ")
-        let account24 = HotAccount(phrase: phrase24, network: .mainnetBeta)!
+        let account24 = HotAccount(phrase: phrase24)!
         XCTAssertEqual(account24.publicKey.base58EncodedString, "9avcmC97zLPwHKXiDz6GpXyjvPn9VcN3ggqM5gsRnjvv")
     }
     
     func testRestoreAccountFromSeedPhraseBip32Deprecated() {
         let phrase24 = "hint begin crowd dolphin drive render finger above sponsor prize runway invest dizzy pony bitter trial ignore crop please industry hockey wire use side"
             .components(separatedBy: " ")
-        let account24 = HotAccount(phrase: phrase24, network: .mainnetBeta, derivablePath: DerivablePath(
+        let account24 = HotAccount(phrase: phrase24, derivablePath: DerivablePath(
             type: .bip32Deprecated,
             walletIndex: 0,
             accountIndex: 0

--- a/Tests/SolanaTests/TokenInfo/TokenInfoTests.swift
+++ b/Tests/SolanaTests/TokenInfo/TokenInfoTests.swift
@@ -11,7 +11,7 @@ class TokenInfoTests: XCTestCase {
         let wallet: TestsWallet = .devnet
         let tokenProvider = try! TokenListProvider(path: getFileFrom("TokenInfo/mainnet-beta.tokens"))
         solanaSDK = Solana(router: NetworkingRouter(endpoint: endpoint), tokenProvider: tokenProvider)
-        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
+        account = HotAccount(phrase: wallet.testAccount.components(separatedBy: " "))!
     }
     
     func testCloseAccountInstruction() {


### PR DESCRIPTION
## Description
- Addresses in solana are the same in Mainnet-beta Devnet and Testnet. They do not need the Network

## Work Completed
- Remove all networking from HotWallet

## API Changes
- HotWallet now doesnt have network

Fixes #203