### PR TITLE
Non escaped encodable

### DIFF
--- a/Sources/Solana/Networking/Router/NetworkingRouter.swift
+++ b/Sources/Solana/Networking/Router/NetworkingRouter.swift
@@ -44,7 +44,7 @@ public class NetworkingRouter: SolanaRouter {
 
             do {
                 let encoder = JSONEncoder()
-                if #available(iOS 13.0, *) {
+                if #available(iOS 13.0, macOS 10.15, *) {
                     // There may be bugs on older versions of iOS here. Consider upping the minimum version, or figure out some different way of doing this
                     encoder.outputFormatting = .withoutEscapingSlashes
                 }

--- a/Sources/Solana/Networking/Router/NetworkingRouter.swift
+++ b/Sources/Solana/Networking/Router/NetworkingRouter.swift
@@ -44,8 +44,11 @@ public class NetworkingRouter: SolanaRouter {
 
             do {
                 let encoder = JSONEncoder()
-                encoder.outputFormatting = .withoutEscapingSlashes
-                urlRequest.httpBody = try JSONEncoder().encode(requestAPI)
+                if #available(iOS 13.0, *) {
+                    // There may be bugs on older versions of iOS here. Consider upping the minimum version, or figure out some different way of doing this
+                    encoder.outputFormatting = .withoutEscapingSlashes
+                }
+                urlRequest.httpBody = try encoder.encode(requestAPI)
                 cb(.success(urlRequest))
                 return
             } catch let ecodingError {

--- a/Sources/Solana/Networking/Router/NetworkingRouter.swift
+++ b/Sources/Solana/Networking/Router/NetworkingRouter.swift
@@ -43,6 +43,8 @@ public class NetworkingRouter: SolanaRouter {
             urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
             do {
+                let encoder = JSONEncoder()
+                encoder.outputFormatting = .withoutEscapingSlashes
                 urlRequest.httpBody = try JSONEncoder().encode(requestAPI)
                 cb(.success(urlRequest))
                 return


### PR DESCRIPTION
## Description
- There were some issues with formatting transaction hashes in encoded JSON objects. Certain characters were getting escaped twice in the JSON field values, leading to them to fail to simulate.

## Work Completed
- Updated the parameters on the JSON encoder to tell it not to escape JSON string values
- NOTE: The fix uses a feature only available on iOS 13+. Is it acceptable to update the minimum version to this, or does a fix need to be found that also works on older versions?

## Testing
- Transactions which were failing to simulate now simulate and complete successfully