### PR TITLE
Adds support for tweaking preflight behaviour on transactions

### DIFF
--- a/Sources/Solana/Models/SolanaSDK+Request.swift
+++ b/Sources/Solana/Models/SolanaSDK+Request.swift
@@ -35,6 +35,7 @@ public struct RequestConfiguration: Encodable {
     public let limit: Int?
     public let before: String?
     public let until: String?
+    public let skipPreflight: Bool?
 
     public init?(
         commitment: Commitment? = nil,
@@ -43,7 +44,8 @@ public struct RequestConfiguration: Encodable {
         filters: [[String: EncodableWrapper]]? = nil,
         limit: Int? = nil,
         before: String? = nil,
-        until: String? = nil
+        until: String? = nil,
+        skipPreflight: Bool? = nil
     ) {
         if commitment == nil
             && encoding == nil
@@ -51,7 +53,8 @@ public struct RequestConfiguration: Encodable {
             && filters == nil
             && limit == nil
             && before == nil
-            && until == nil {
+            && until == nil
+            && skipPreflight == nil {
             return nil
         }
         self.commitment = commitment
@@ -61,6 +64,7 @@ public struct RequestConfiguration: Encodable {
         self.limit = limit
         self.before = before
         self.until = until
+        self.skipPreflight = skipPreflight
     }
 }
 

--- a/Sources/Solana/Models/SolanaSDK+Request.swift
+++ b/Sources/Solana/Models/SolanaSDK+Request.swift
@@ -36,6 +36,7 @@ public struct RequestConfiguration: Encodable {
     public let before: String?
     public let until: String?
     public let skipPreflight: Bool?
+    public let preflightCommitment: Commitment?
 
     public init?(
         commitment: Commitment? = nil,
@@ -45,7 +46,8 @@ public struct RequestConfiguration: Encodable {
         limit: Int? = nil,
         before: String? = nil,
         until: String? = nil,
-        skipPreflight: Bool? = nil
+        skipPreflight: Bool? = nil,
+        preflightCommitment: Commitment? = nil
     ) {
         if commitment == nil
             && encoding == nil
@@ -54,7 +56,8 @@ public struct RequestConfiguration: Encodable {
             && limit == nil
             && before == nil
             && until == nil
-            && skipPreflight == nil {
+            && skipPreflight == nil
+            && preflightCommitment == nil {
             return nil
         }
         self.commitment = commitment
@@ -65,6 +68,7 @@ public struct RequestConfiguration: Encodable {
         self.before = before
         self.until = until
         self.skipPreflight = skipPreflight
+        self.preflightCommitment = preflightCommitment
     }
 }
 


### PR DESCRIPTION
## Description
Adds support for skipping preflight checks and setting the preflight commitment level on transactions. This resolves issues where setting the transaction commitment level could result in frequent "Blockhash Not found" errors when setting the transaction commitment level any lower than finalized

## API Changes
`RequestConfiguration` gains 2 new fields: `skipPreflight` and `preflightCommitment`, which behave exactly as detailed here: https://docs.solana.com/api/http#sendtransaction

## Testing
Verified in our own app that skipping preflight and setting various commitment levels behave as expected.